### PR TITLE
Secure Argus producer queue access

### DIFF
--- a/lib/src/ArgusBayerCapture.cpp
+++ b/lib/src/ArgusBayerCapture.cpp
@@ -868,9 +868,11 @@ void ArgusBayerCapture::produce()
               int c_res= convert((void*)iFrameLeft,newImage);
               if (c_res==0)
                 {
+                  enterCriticalSection();
                   if (mCaptureQueue.size()>MAX_CAPTURE_QUEUE_SIZE)
                     mCaptureQueue.pop_front();
                   mCaptureQueue.push_back(newImage);
+                  exitCriticalSection();
                 }
                 else
                 mArgusGrabState = ARGUS_STATE::CAPTURE_CONVERT_FAILURE;


### PR DESCRIPTION
Problem: With the correct timing the `produce`r thread removes the front of the communication queue https://github.com/stereolabs/zedx-one-capture/blob/main/lib/src/ArgusBayerCapture.cpp#L872, while the `consume`r thread is actively copying the image out in https://github.com/stereolabs/zedx-one-capture/blob/main/lib/src/ArgusBayerCapture.cpp#L946. This can happen if the `consume`r is a little bit too slow (maybe due to scheduling) and the queue grows to more than two element.

Solution: While the `consume`r secures its access to the queue with a lock, the `produce`r does not. This change fixes that.