### PR TITLE
Add wb_test validation tool (with manual-WB per-sensor fix)

### DIFF
--- a/wb_test/CMakeLists.txt
+++ b/wb_test/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(wb_test)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+# Argus capture library (built from parent lib/)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../lib/include)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../lib/build)
+
+# Tegra MM
+set(TegraMM_ROOT /usr/src/jetson_multimedia_api)
+if(EXISTS ${TegraMM_ROOT})
+  include_directories(
+    ${TegraMM_ROOT}/include
+    ${TegraMM_ROOT}/include/libjpeg-8b
+    /usr/include/libdrm
+  )
+  link_directories(
+    /usr/lib/aarch64-linux-gnu/tegra
+    /usr/lib/aarch64-linux-gnu
+    /usr/lib/aarch64-linux-gnu/nvidia
+  )
+  set(TegraMM_LIBRARIES
+    nvargus_socketclient nvjpeg drm nvbufsurftransform
+    nvbufsurface nvosd EGL v4l2 GLESv2 X11 pthread vulkan
+  )
+endif()
+
+add_executable(wb_test main.cpp)
+target_link_libraries(wb_test arguscapture pthread ${OpenCV_LIBRARIES} ${TegraMM_LIBRARIES})

--- a/wb_test/README.md
+++ b/wb_test/README.md
@@ -1,0 +1,61 @@
+# wb_test
+
+A local validation tool for the ZED X One capture library. It opens a single
+camera and sweeps through the white balance, exposure, and gain controls
+exposed by `oc::ArgusBayerCapture`, printing the reported state at each step and
+saving a sample image so the results can be compared visually.
+
+This is a developer diagnostic tool — it is **not** part of the public samples
+and is not intended for distribution.
+
+## What it does
+
+For each stage the tool waits for the settings to settle, prints the values read
+back from the camera, and writes a PNG to `/tmp/wb_test/`:
+
+- **White balance** — auto WB baseline, the preset AWB modes (incandescent,
+  fluorescent, warm fluorescent, daylight, cloudy daylight), and a manual color
+  temperature sweep (2800 K – 8000 K).
+- **Exposure** — auto baseline, exposure-range clamping, manual exposure by
+  percent and by time, and EV compensation (−2 to +2).
+- **Gain** — auto analog gain, a manual analog gain sweep in dB, auto digital
+  gain, and a manual digital gain sweep (1×–8×).
+
+At the end it restores automatic exposure, gain, and white balance before
+closing the camera.
+
+## Building and running
+
+The `build_and_run.sh` helper builds the parent library in `../lib`, builds this
+tool, and runs it:
+
+```
+./build_and_run.sh [camera_id] [settle_frames]
+```
+
+- `camera_id` — device index to open (default `0`).
+- `settle_frames` — number of frames to capture between each setting change so
+  the sensor can stabilize (default `15`).
+
+To build manually instead:
+
+```
+mkdir build; cd build; cmake ..
+make
+export LD_LIBRARY_PATH="../../lib/build:$LD_LIBRARY_PATH"
+./wb_test 0 15
+```
+
+## Requirements
+
+- An NVIDIA Jetson with the ZED X One drivers installed (see the
+  [getting started guide](https://www.stereolabs.com/docs/get-started-with-zed-x-one)).
+- OpenCV (used to convert and save the sample frames).
+- The Argus capture library built in `../lib/build`.
+
+## Output
+
+Sample images are written to `/tmp/wb_test/`, named after each stage (for
+example `auto.png`, `awb_daylight.png`, `manual_5000K.png`, `exp_manual_50pct.png`,
+`gain_analog_60db.png`). Press `Ctrl+C` at any time to stop early; the current
+sweep is interrupted and the camera is closed cleanly.

--- a/wb_test/build_and_run.sh
+++ b/wb_test/build_and_run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build the library + test app and run. Usage:
+#   ./build_and_run.sh [camera_id] [settle_frames]
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+echo "=== Building library ==="
+cd "$LIB_DIR"
+mkdir -p build && cd build
+cmake -DCMAKE_CXX_FLAGS="-L/usr/lib/aarch64-linux-gnu/nvidia" .. 2>&1 | tail -3
+make -j$(nproc)
+
+echo "=== Building test app ==="
+cd "$SCRIPT_DIR"
+mkdir -p build && cd build
+cmake .. 2>&1 | tail -3
+make -j$(nproc)
+
+echo "=== Running WB test ==="
+export LD_LIBRARY_PATH="$LIB_DIR/build:$LD_LIBRARY_PATH"
+./wb_test "$@"

--- a/wb_test/main.cpp
+++ b/wb_test/main.cpp
@@ -1,0 +1,249 @@
+#include <signal.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "ArgusCapture.hpp"
+#include "opencv2/opencv.hpp"
+
+volatile sig_atomic_t interrupted = false;
+void signal_end(int) { interrupted = true; }
+
+static void captureFrames(oc::ArgusBayerCapture& cam, cv::Mat& frame, int n) {
+  int channels = cam.getNumberOfChannels();
+  size_t nbytes =
+      static_cast<size_t>(cam.getWidth()) * cam.getHeight() * channels;
+  for (int i = 0; i < n && !interrupted; i++) {
+    while (!interrupted && !cam.isNewFrame()) usleep(100);
+    std::memcpy(frame.data, cam.getPixels(), nbytes);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  struct sigaction sa = {};
+  sa.sa_handler = signal_end;
+  sigaction(SIGINT, &sa, nullptr);
+
+  int camera_id = 0;
+  int settle = 15;
+  if (argc > 1) camera_id = atoi(argv[1]);
+  if (argc > 2) settle = atoi(argv[2]);
+
+  oc::ArgusCameraConfig config;
+  config.mDeviceId = camera_id;
+  config.mWidth = 1920;
+  config.mHeight = 1080;
+  config.mFPS = 15;
+  config.hdr = false;
+  config.mSwapRB = true;
+  config.verbose_level = 1;
+
+  oc::ArgusBayerCapture cam;
+  auto state = cam.openCamera(config);
+  if (state != oc::ARGUS_STATE::OK) {
+    std::cerr << "Failed to open camera: " << oc::ARGUS_STATE2str(state)
+              << std::endl;
+    return 1;
+  }
+
+  cv::Mat frame(cam.getHeight(), cam.getWidth(), CV_8UC4);
+
+  // Initial settle
+  std::cout << "Settling " << settle << " frames..." << std::endl;
+  captureFrames(cam, frame, settle);
+
+  std::string outdir = "/tmp/wb_test";
+  std::string mkdir_cmd = "mkdir -p " + outdir;
+  system(mkdir_cmd.c_str());
+
+  auto saveFrame = [&](const std::string& name) {
+    cv::Mat bgr;
+    cv::cvtColor(frame, bgr, cv::COLOR_RGBA2BGR);
+    std::string path = outdir + "/" + name + ".png";
+    cv::imwrite(path, bgr);
+    std::cout << "  Saved " << path << std::endl;
+  };
+
+  auto printGains = [&]() {
+    float g[4];
+    cam.getAwbGains(g);
+    std::cout << "  AWB gains: R=" << g[0] << " Ge=" << g[1]
+              << " Go=" << g[2] << " B=" << g[3] << std::endl;
+  };
+
+  // Test auto WB as baseline
+  std::cout << "\n=== Auto WB ===" << std::endl;
+  cam.setAutomaticWhiteBalance(1);
+  captureFrames(cam, frame, settle);
+  std::cout << "  WB status=" << cam.getAutomaticWhiteBalanceStatus()
+            << " temp=" << cam.getManualWhiteBalance() << "K" << std::endl;
+  printGains();
+  saveFrame("auto");
+
+  // Test preset AWB modes
+  std::vector<std::pair<int, std::string>> awb_modes = {
+      {2, "incandescent"},   {3, "fluorescent"},
+      {4, "warm_fluor"},     {5, "daylight"},
+      {6, "cloudy_daylight"}};
+  for (auto& [mode, name] : awb_modes) {
+    std::cout << "\n=== AWB mode " << mode << " (" << name << ") ==="
+              << std::endl;
+    cam.setAutomaticWhiteBalance(mode);
+    captureFrames(cam, frame, settle);
+    std::cout << "  WB status=" << cam.getAutomaticWhiteBalanceStatus()
+              << " temp=" << cam.getManualWhiteBalance() << "K" << std::endl;
+    printGains();
+    saveFrame("awb_" + name);
+  }
+
+  // Sweep manual temps
+  std::vector<uint32_t> temps = {2800, 3200, 3500, 4000, 4500,
+                                 5000, 5500, 6000, 6500, 8000};
+  for (uint32_t t : temps) {
+    if (interrupted) break;
+    std::cout << "\n=== Manual " << t << "K ===" << std::endl;
+    int rc = cam.setManualWhiteBalance(t);
+    std::cout << "  setManualWhiteBalance(" << t << ") -> " << rc << std::endl;
+    captureFrames(cam, frame, settle);
+    std::cout << "  WB status=" << cam.getAutomaticWhiteBalanceStatus()
+              << " temp=" << cam.getManualWhiteBalance() << "K" << std::endl;
+    printGains();
+    saveFrame("manual_" + std::to_string(t) + "K");
+  }
+
+  // ================================================================
+  // Exposure sweep - restore auto WB first for consistent comparison
+  // ================================================================
+  std::cout << "\n\n======== EXPOSURE SWEEP ========" << std::endl;
+  cam.setAutomaticWhiteBalance(1);
+  captureFrames(cam, frame, settle);
+
+  auto printExposure = [&]() {
+    std::cout << "  Exposure: " << cam.getFrameExposureTime() << " us ("
+              << cam.getFrameExposurePercent() << "%)"
+              << "  Analog gain: " << cam.getAnalogFrameGain() << " dB"
+              << "  Digital gain: " << cam.getDigitalFrameGain() << std::endl;
+  };
+
+  // Auto exposure baseline
+  std::cout << "\n=== Auto Exposure (baseline) ===" << std::endl;
+  cam.setAutomaticExposure();
+  captureFrames(cam, frame, settle);
+  printExposure();
+  saveFrame("exp_auto");
+
+  // Exposure range clamping
+  std::vector<std::pair<uint64_t, uint64_t>> exp_ranges = {
+      {16, 5000}, {16, 10000}, {16, 20000}, {16, 33000}, {16, 39000}};
+  for (auto& [lo, hi] : exp_ranges) {
+    if (interrupted) break;
+    std::cout << "\n=== Exposure range " << lo << "-" << hi << " us ==="
+              << std::endl;
+    cam.setAutomaticExposure();
+    cam.setFrameExposureRange(lo, hi);
+    captureFrames(cam, frame, settle);
+    printExposure();
+    uint64_t rlo = 0, rhi = 0;
+    cam.getFrameExposureRange(rlo, rhi);
+    std::cout << "  Readback range: " << rlo << " - " << rhi << " us"
+              << std::endl;
+    saveFrame("exp_range_" + std::to_string(lo) + "_" + std::to_string(hi));
+  }
+
+  // Manual exposure by percent
+  std::vector<int> exp_pcts = {10, 25, 50, 75, 100};
+  for (int pct : exp_pcts) {
+    if (interrupted) break;
+    std::cout << "\n=== Manual Exposure " << pct << "% ===" << std::endl;
+    int rc = cam.setManualExposure(pct);
+    std::cout << "  setManualExposure(" << pct << ") -> " << rc << std::endl;
+    captureFrames(cam, frame, settle);
+    printExposure();
+    saveFrame("exp_manual_" + std::to_string(pct) + "pct");
+  }
+
+  // Manual exposure by time
+  std::vector<uint64_t> exp_times = {1000, 5000, 10000, 20000, 33000};
+  for (uint64_t t : exp_times) {
+    if (interrupted) break;
+    std::cout << "\n=== Manual Exposure " << t << " us ===" << std::endl;
+    int rc = cam.setManualTimeExposure(t);
+    std::cout << "  setManualTimeExposure(" << t << ") -> " << rc << std::endl;
+    captureFrames(cam, frame, settle);
+    printExposure();
+    saveFrame("exp_time_" + std::to_string(t) + "us");
+  }
+
+  // EV compensation
+  cam.setAutomaticExposure();
+  cam.setFrameExposureRange(16, 39000);  // Reset range
+  std::vector<float> ev_values = {-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0};
+  for (float ev : ev_values) {
+    if (interrupted) break;
+    std::cout << "\n=== EV Compensation " << ev << " ===" << std::endl;
+    int rc = cam.setExposureCompensation(ev);
+    std::cout << "  setExposureCompensation(" << ev << ") -> " << rc
+              << std::endl;
+    captureFrames(cam, frame, settle);
+    printExposure();
+    saveFrame("exp_ev_" + std::to_string(static_cast<int>(ev * 10)));
+  }
+
+  // Analog gain modes
+  std::cout << "\n\n======== GAIN SWEEP ========" << std::endl;
+  cam.setAutomaticExposure();
+  cam.setExposureCompensation(0.0);
+
+  std::cout << "\n=== Auto Analog Gain ===" << std::endl;
+  cam.setAutomaticAnalogGain();
+  captureFrames(cam, frame, settle);
+  printExposure();
+  saveFrame("gain_analog_auto");
+
+  std::vector<float> ag_db = {0.1, 3.0, 6.0, 12.0, 20.0};
+  for (float db : ag_db) {
+    if (interrupted) break;
+    std::cout << "\n=== Manual Analog Gain " << db << " dB ===" << std::endl;
+    int rc = cam.setManualAnalogGainReal(db);
+    std::cout << "  setManualAnalogGainReal(" << db << ") -> " << rc
+              << std::endl;
+    captureFrames(cam, frame, settle);
+    printExposure();
+    saveFrame("gain_analog_" + std::to_string(static_cast<int>(db * 10))
+              + "db");
+  }
+
+  // Restore auto for digital gain test
+  cam.setAutomaticAnalogGain();
+
+  std::cout << "\n=== Auto Digital Gain ===" << std::endl;
+  cam.setAutomaticDigitalGain();
+  captureFrames(cam, frame, settle);
+  printExposure();
+  saveFrame("gain_digital_auto");
+
+  std::vector<int> dg_factors = {1, 2, 4, 8};
+  for (int f : dg_factors) {
+    if (interrupted) break;
+    std::cout << "\n=== Manual Digital Gain factor=" << f << " ==="
+              << std::endl;
+    int rc = cam.setManualDigitalGainReal(f);
+    std::cout << "  setManualDigitalGainReal(" << f << ") -> " << rc
+              << std::endl;
+    captureFrames(cam, frame, settle);
+    printExposure();
+    saveFrame("gain_digital_" + std::to_string(f) + "x");
+  }
+
+  // Restore auto
+  cam.setAutomaticDigitalGain();
+  cam.setAutomaticAnalogGain();
+  cam.setAutomaticExposure();
+
+  std::cout << "\n=== Done. Images in " << outdir << " ===" << std::endl;
+  cam.closeCamera();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds the `wb_test` diagnostic tool for validating white-balance / exposure / gain behaviour on real hardware, **including** the manual-WB fix code it was used to validate.

This is a **draft** and overlaps [#19](https://github.com/stereolabs/zedx-one-capture/pull/19) (it carries the same manual-WB fix). Opening it primarily to share the validation tooling and the on-hardware results.

## What's here

- **`wb_test/`** — standalone tool that sweeps manual WB color temperatures, AWB presets, exposure (percent / time / EV / range) and analog+digital gain, saving a PNG per setting to `/tmp/wb_test/` and printing readback gains. Build+run via `wb_test/build_and_run.sh [camera_id] [settle_frames]`.
- **AWB gain readback** — `getAwbGains(float[4])` plus `argusMonoImage::frameAwbGains`, populated from capture metadata, so measured RGGB gains can be compared against what was requested.
- **Manual-WB fix** — corrected gain computation (inverse-of-illuminant, min-normalized) with a **per-sensor green bias**: the imx678 (4K) has a green-dominant raw response and needs green halved to avoid a green cast; other sensors (e.g. the GS variant) use unity.

## Validation

On-hardware sweeps (imx678 4K) showed manual 6500K matching the AWB daylight reference once the per-sensor bias is applied; removing the bias (unity green) reintroduced a strong green cast. Readback gains track the AWB ground truth across the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
