### PR TITLE
Add configurable ISP source-clip rect (ROI crop / native center crop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ Run the sample
 ```
 ./argus_camera
 ```
+
+## ISP source-clip (ROI crop / zoom)
+
+`oc::ArgusCameraConfig` supports a normalized ISP source-clip rectangle, letting
+the camera crop and rescale the sensor image on-chip before it reaches your
+application:
+
+- `mClipLeft` / `mClipTop` / `mClipRight` / `mClipBottom` — a normalized `[0,1]`
+  clip rectangle over the sensor (source) frame (full frame = `{0, 0, 1, 1}`).
+  The ISP clips the source to this rectangle and rescales it to the output
+  resolution `mWidth` × `mHeight`.
+- `mSensorWidth` / `mSensorHeight` — the sensor-mode (source readout) resolution.
+  Leave at `0` to use `mWidth` / `mHeight` (source == output, so a clip is a
+  digital zoom). Set larger than the output to read the sensor at higher
+  resolution, so a clip yields a true 1:1 crop at native detail instead of a
+  zoom (e.g. sensor `3840×2160`, output `1920×1080`, centered clip → native
+  center crop).
+
+An out-of-range or inverted clip rectangle causes `openCamera()` to fail with
+`INVALID_SOURCE_CONFIGURATION`.
+
+See [`sample_roi`](sample_roi/) for a standalone tool that exercises this
+feature.

--- a/lib/include/ArgusCapture.hpp
+++ b/lib/include/ArgusCapture.hpp
@@ -109,6 +109,12 @@ public:
     PixelMode mode = PixelMode::COLOR_RGBA;
     bool hdr = false;
     bool mSwapRB = false; //swap for RGB(A) or BGR(A) output. Not available for RAW10
+    // Normalized ISP source-clip rect in [0,1] over the source frame; full frame = {0,0,1,1}.
+    // Clips the source and rescales it to mWidth x mHeight (ISP digital crop / zoom).
+    float mClipLeft = 0.f;
+    float mClipTop = 0.f;
+    float mClipRight = 1.f;
+    float mClipBottom = 1.f;
     int verbose_level = 0;
 };
 

--- a/lib/include/ArgusCapture.hpp
+++ b/lib/include/ArgusCapture.hpp
@@ -105,6 +105,13 @@ public:
     uint32_t mDeviceId=0;
     uint32_t mWidth=0;
     uint32_t mHeight=0;
+    // Sensor-mode (source readout) resolution. 0 = use mWidth/mHeight (source ==
+    // output). Set larger than mWidth/mHeight to read the sensor at a higher
+    // resolution than the output stream, so an ISP source-clip yields a true 1:1
+    // crop instead of a digital zoom (e.g. sensor 3840x2160, output 1920x1080,
+    // centered clip -> native-detail center crop).
+    uint32_t mSensorWidth=0;
+    uint32_t mSensorHeight=0;
     uint32_t mFPS=0;
     PixelMode mode = PixelMode::COLOR_RGBA;
     bool hdr = false;

--- a/lib/src/ArgusBayerCapture.cpp
+++ b/lib/src/ArgusBayerCapture.cpp
@@ -419,15 +419,24 @@ ARGUS_STATE ArgusBayerCapture::openCamera(const ArgusCameraConfig &config,bool r
     }
 
 
-  //2. Find sensor mode according to width/height. If width or height = 0, choose the first / default sensor mode
+  //2. Find sensor mode. The sensor mode (source readout) is selected by
+  //   mSensorWidth/mSensorHeight when set (>0), otherwise by mWidth/mHeight.
+  //   The output stream stays at mWidth/mHeight, so a larger sensor mode plus an
+  //   ISP source-clip gives a true 1:1 crop instead of a digital zoom. If the
+  //   sensor target or the output is 0, choose the first / default sensor mode.
+  const uint32_t sensor_target_w =
+      mConfig.mSensorWidth > 0 ? mConfig.mSensorWidth : mConfig.mWidth;
+  const uint32_t sensor_target_h =
+      mConfig.mSensorHeight > 0 ? mConfig.mSensorHeight : mConfig.mHeight;
   int m_sensor_mode = -1;
-  if (mConfig.mWidth==0 || mConfig.mHeight == 0)
+  if (sensor_target_w==0 || sensor_target_h == 0)
   {
       //Take the first sensor mode
       m_sensor_mode = 0;
       ISensorMode* ssmode = Argus::interface_cast<Argus::ISensorMode>(sensorModes[m_sensor_mode]);
-      mConfig.mWidth = ssmode->getResolution().width();
-      mConfig.mHeight = ssmode->getResolution().height();
+      // Default the output size to the sensor mode when it was left unspecified.
+      if (mConfig.mWidth==0)  mConfig.mWidth = ssmode->getResolution().width();
+      if (mConfig.mHeight==0) mConfig.mHeight = ssmode->getResolution().height();
       if (mConfig.mFPS==0)
           mConfig.mFPS = ONE_SECOND_NANOS/ssmode->getFrameDurationRange().min();
 
@@ -445,7 +454,7 @@ ARGUS_STATE ArgusBayerCapture::openCamera(const ArgusCameraConfig &config,bool r
 
       if(mConfig.hdr)
       {
-          if (mConfig.mWidth==s_width && mConfig.mHeight == s_height && hdr_ratio_max > 1)
+          if (sensor_target_w==s_width && sensor_target_h == s_height && hdr_ratio_max > 1)
             {
               m_sensor_mode = k;
               if (mConfig.mFPS==0)
@@ -455,7 +464,7 @@ ARGUS_STATE ArgusBayerCapture::openCamera(const ArgusCameraConfig &config,bool r
       }
       else
       {
-          if (mConfig.mWidth==s_width && mConfig.mHeight == s_height )
+          if (sensor_target_w==s_width && sensor_target_h == s_height )
             {
               m_sensor_mode = k;
               if (mConfig.mFPS==0)

--- a/lib/src/ArgusBayerCapture.cpp
+++ b/lib/src/ArgusBayerCapture.cpp
@@ -611,8 +611,19 @@ ARGUS_STATE ArgusBayerCapture::openCamera(const ArgusCameraConfig &config,bool r
       return ARGUS_STATE::INVALID_SOURCE_CONFIGURATION;
     }
 
-  // set stream resolution
-  status = iOutStreamSettings->setSourceClipRect(Argus::Rectangle<float>(0,0,1.f,1.f));
+  // set stream resolution. Clip rect is normalized [0,1] over the source frame
+  // (full frame = {0,0,1,1}); the clipped region is rescaled to mWidth x mHeight.
+  const bool clip_valid =
+      mConfig.mClipLeft >= 0.f && mConfig.mClipTop >= 0.f &&
+      mConfig.mClipRight <= 1.f && mConfig.mClipBottom <= 1.f &&
+      mConfig.mClipLeft < mConfig.mClipRight &&
+      mConfig.mClipTop < mConfig.mClipBottom;
+  if (!clip_valid) {
+      ArgusProvider::changeState(mPort,ARGUS_CAMERA_STATE::OFF);
+      return ARGUS_STATE::INVALID_SOURCE_CONFIGURATION;
+    }
+  status = iOutStreamSettings->setSourceClipRect(Argus::Rectangle<float>(
+      mConfig.mClipLeft, mConfig.mClipTop, mConfig.mClipRight, mConfig.mClipBottom));
   if (Argus::STATUS_OK != status) {
       return ARGUS_STATE::INVALID_SOURCE_CONFIGURATION;
     }

--- a/sample_roi/CMakeLists.txt
+++ b/sample_roi/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(argus_roi_test)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(OpenCV REQUIRED)
+include_directories(${OPENCV_INCLUDE_DIRS})
+link_directories(${OpenCV_LIBRARY_DIRS})
+
+set(TegraMM_ROOT /usr/src/jetson_multimedia_api)
+set(TegraMM_FOUND FALSE)
+
+if(EXISTS ${TegraMM_ROOT})
+  # set packages
+  set(TegraMM_INCLUDE_DIRS ${TegraMM_ROOT}/include ${TegraMM_ROOT}/include/libjpeg-8b /usr/include/libdrm)
+  set(TegraMM_LIBRARY_DIRS /usr/lib/aarch64-linux-gnu/tegra /usr/lib/aarch64-linux-gnu)
+  set(TegraMM_LIBRARIES nvargus_socketclient nvjpeg drm nvbufsurftransform nvbufsurface nvosd EGL v4l2 GLESv2 X11 pthread vulkan)
+  file(GLOB TegraMM_COMMON_SOURCES ${TegraMM_ROOT}/samples/common/classes/*.cpp)
+  include_directories(${TegraMM_INCLUDE_DIRS})
+  link_directories(${TegraMM_LIBRARY_DIRS})
+  set(TegraMM_FOUND TRUE)
+endif()
+
+add_definitions(-std=c++14 -O3)
+IF (BUILD_WITH_DEBUGINFOS)
+    message("!! Building with -g !!")
+    add_definitions(-g)
+    set(ARGUS_LIB arguscaptured)
+ELSE()
+    set(ARGUS_LIB arguscapture)
+ENDIF()
+
+add_executable(argus_roi_test main.cpp)
+target_link_libraries(argus_roi_test ${ARGUS_LIB} pthread ${OpenCV_LIBRARIES} ${TegraMM_LIBRARIES})

--- a/sample_roi/README.md
+++ b/sample_roi/README.md
@@ -1,0 +1,89 @@
+# sample_roi — ISP source-clip (ROI) smoke test
+
+A standalone tool for validating the configurable **ISP source-clip rect** added
+to the ZED X One capture library. It opens a single mono camera with a given
+clip rectangle, grabs one frame after a short warmup, and writes it to a PNG so
+the crop/zoom can be eyeballed. It is fully headless (no `imshow`), so it runs
+over SSH.
+
+## The feature
+
+`oc::ArgusCameraConfig` gains two independent controls:
+
+- **Source clip rect** — `mClipLeft` / `mClipTop` / `mClipRight` / `mClipBottom`,
+  a normalized `[0,1]` rectangle over the sensor (source) frame. The full frame
+  is `{0, 0, 1, 1}`. The ISP clips the source to this rectangle and rescales it
+  to the output resolution (`mWidth` × `mHeight`). An invalid rect (out of
+  `[0,1]`, or left ≥ right / top ≥ bottom) fails `openCamera` with
+  `INVALID_SOURCE_CONFIGURATION`.
+
+- **Sensor mode decoupled from output** — `mSensorWidth` / `mSensorHeight`.
+  When `0`, the sensor mode is selected from `mWidth`/`mHeight` as before (source
+  == output). When set larger than the output, the sensor is read at a higher
+  resolution than the output stream, so a source-clip produces a **true 1:1
+  crop** at native detail instead of a digital zoom.
+
+Combining the two:
+
+| Sensor mode | Output | Clip | Result |
+|-------------|--------|------|--------|
+| == output | 1920×1080 | centered half | digital **zoom** (upscaled) |
+| 3840×2160 | 1920×1080 | centered 1920×1080 | native-detail **1:1 crop** |
+
+## Usage
+
+```
+argus_roi_test <device> <out_w> <out_h> <fps> \
+               <roi_x> <roi_y> <roi_w> <roi_h> \
+               [sensor_w] [sensor_h] [warmup_frames]
+```
+
+- `device` — camera device index.
+- `out_w` / `out_h` / `fps` — output stream resolution and frame rate.
+- `roi_x` / `roi_y` / `roi_w` / `roi_h` — ROI in **sensor (source) pixels**. The
+  tool normalizes it over the sensor mode into a clip rect. `roi_w == 0` (or
+  `roi_h == 0`) captures the full frame.
+- `sensor_w` / `sensor_h` — optional sensor-mode resolution. Defaults to the
+  output size (source == output ⇒ the clip is a digital zoom). Set larger than
+  the output for a true 1:1 crop.
+- `warmup_frames` — frames to discard before saving (default `15`).
+
+Each run prints the computed clip rect and scale factor, then writes
+`roi_x<X>_y<Y>_w<W>_h<H>_s<SW>x<SH>.png`.
+
+### Examples
+
+Centered 1:1 crop of a 4K sensor (no zoom, `scale = 1.0`):
+
+```
+./argus_roi_test 0 1920 1080 15  960 540 1920 1080  3840 2160
+```
+
+2× centered digital zoom (source == output):
+
+```
+./argus_roi_test 0 1920 1080 15  480 270 960 540
+```
+
+Full frame (baseline):
+
+```
+./argus_roi_test 0 1920 1080 15  0 0 0 0
+```
+
+## Building
+
+Build and install the library in `../lib` first (see the top-level README), then:
+
+```
+mkdir build; cd build; cmake ..
+make
+./argus_roi_test 0 1920 1080 15 0 0 0 0
+```
+
+## Requirements
+
+- An NVIDIA Jetson with the ZED X One drivers installed
+  ([getting started guide](https://www.stereolabs.com/docs/get-started-with-zed-x-one)).
+- OpenCV (used to convert and save the sample frame).
+- The Argus capture library from `../lib`.

--- a/sample_roi/main.cpp
+++ b/sample_roi/main.cpp
@@ -1,0 +1,103 @@
+// Copyright 2026 Skyways
+//
+// Standalone ISP source-clip (ROI) smoke test for ZED X One mono capture.
+// Opens the camera with a configurable clip rect, grabs a frame after a short
+// warmup, and writes it to a PNG so the crop/zoom can be eyeballed without ROS
+// or a camera_info publisher. Headless (no imshow) so it runs over SSH.
+//
+// Usage:
+//   argus_roi_test <device> <width> <height> <fps> \
+//                  <roi_x> <roi_y> <roi_w> <roi_h> [warmup_frames]
+//
+// ROI is in full-frame pixels, matching zedxone4k_camera_node's roi_* params.
+// roi_w == 0 (default) captures the full frame. Each run writes
+// roi_x<X>_y<Y>_w<W>_h<H>.png; run once full-frame and once cropped and diff.
+
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+#include "ArgusCapture.hpp"
+#include "opencv2/opencv.hpp"
+
+namespace {
+float clamp01(float v) { return std::min(std::max(v, 0.f), 1.f); }
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  int device = 0, width = 1920, height = 1080, fps = 15;
+  int roi_x = 0, roi_y = 0, roi_w = 0, roi_h = 0, warmup = 15;
+  if (argc > 1) device = atoi(argv[1]);
+  if (argc > 2) width = atoi(argv[2]);
+  if (argc > 3) height = atoi(argv[3]);
+  if (argc > 4) fps = atoi(argv[4]);
+  if (argc > 5) roi_x = atoi(argv[5]);
+  if (argc > 6) roi_y = atoi(argv[6]);
+  if (argc > 7) roi_w = atoi(argv[7]);
+  if (argc > 8) roi_h = atoi(argv[8]);
+  if (argc > 9) warmup = atoi(argv[9]);
+
+  // Normalized clip rect (mirrors ToNormalizedClipRect in the ROS node).
+  float cl = 0.f, ct = 0.f, cr = 1.f, cb = 1.f;
+  const bool roi_on = roi_w > 0 && roi_h > 0 && width > 0 && height > 0;
+  if (roi_on) {
+    cl = clamp01(static_cast<float>(roi_x) / width);
+    ct = clamp01(static_cast<float>(roi_y) / height);
+    cr = clamp01(static_cast<float>(roi_x + roi_w) / width);
+    cb = clamp01(static_cast<float>(roi_y + roi_h) / height);
+  }
+  std::cout << "ROI " << (roi_on ? "ENABLED" : "disabled") << " x=" << roi_x
+            << " y=" << roi_y << " w=" << roi_w << " h=" << roi_h
+            << " -> clip [" << cl << ", " << ct << ", " << cr << ", " << cb
+            << "]  output " << width << "x" << height << std::endl;
+
+  oc::ArgusCameraConfig config;
+  config.mDeviceId = device;
+  config.mWidth = width;
+  config.mHeight = height;
+  config.mFPS = fps;
+  config.verbose_level = 1;
+  config.mClipLeft = cl;
+  config.mClipTop = ct;
+  config.mClipRight = cr;
+  config.mClipBottom = cb;
+
+  oc::ArgusBayerCapture camera;
+  oc::ARGUS_STATE state = camera.openCamera(config);
+  if (state != oc::ARGUS_STATE::OK) {
+    // An invalid clip rect trips the new validation -> INVALID_SOURCE_CONFIGURATION.
+    std::cerr << "openCamera failed: " << oc::ARGUS_STATE2str(state) << std::endl;
+    return 1;
+  }
+
+  cv::Mat rgba(camera.getHeight(), camera.getWidth(), CV_8UC4);
+  int got = 0;
+  for (int i = 0; i < warmup + 1;) {
+    if (camera.isNewFrame()) {
+      std::memcpy(rgba.data, camera.getPixels(),
+                  static_cast<size_t>(camera.getWidth()) * camera.getHeight() *
+                      camera.getNumberOfChannels());
+      got = ++i;
+    } else {
+      usleep(1000);
+    }
+  }
+  camera.closeCamera();
+  if (got == 0) {
+    std::cerr << "No frames captured" << std::endl;
+    return 2;
+  }
+
+  cv::Mat bgr;
+  cv::cvtColor(rgba, bgr, cv::COLOR_RGBA2BGR);
+  char name[128];
+  snprintf(name, sizeof(name), "roi_x%d_y%d_w%d_h%d.png", roi_x, roi_y, roi_w,
+           roi_h);
+  cv::imwrite(name, bgr);
+  std::cout << "Wrote " << name << " (" << bgr.cols << "x" << bgr.rows << ")"
+            << std::endl;
+  return 0;
+}

--- a/sample_roi/main.cpp
+++ b/sample_roi/main.cpp
@@ -6,12 +6,17 @@
 // or a camera_info publisher. Headless (no imshow) so it runs over SSH.
 //
 // Usage:
-//   argus_roi_test <device> <width> <height> <fps> \
-//                  <roi_x> <roi_y> <roi_w> <roi_h> [warmup_frames]
+//   argus_roi_test <device> <out_w> <out_h> <fps> \
+//                  <roi_x> <roi_y> <roi_w> <roi_h> \
+//                  [sensor_w] [sensor_h] [warmup_frames]
 //
-// ROI is in full-frame pixels, matching zedxone4k_camera_node's roi_* params.
-// roi_w == 0 (default) captures the full frame. Each run writes
-// roi_x<X>_y<Y>_w<W>_h<H>.png; run once full-frame and once cropped and diff.
+// ROI is in SENSOR (source) pixels; the clip is normalized over the sensor mode.
+// sensor_w/sensor_h default to the output size (source == output => the ISP clip
+// is a digital zoom). Set the sensor larger than the output for a true 1:1 crop,
+// e.g. out 1920x1080, sensor 3840x2160, roi 960 540 1920 1080 -> centered 1080
+// crop of the 4K sensor at native detail (scale = 1.0, no zoom).
+// roi_w == 0 captures the full frame. Each run writes
+// roi_x<X>_y<Y>_w<W>_h<H>_s<SW>x<SH>.png.
 
 #include <time.h>
 #include <unistd.h>
@@ -28,36 +33,51 @@ float clamp01(float v) { return std::min(std::max(v, 0.f), 1.f); }
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  int device = 0, width = 1920, height = 1080, fps = 15;
-  int roi_x = 0, roi_y = 0, roi_w = 0, roi_h = 0, warmup = 15;
+  int device = 0, out_w = 1920, out_h = 1080, fps = 15;
+  int roi_x = 0, roi_y = 0, roi_w = 0, roi_h = 0;
+  int sensor_w = 0, sensor_h = 0, warmup = 15;
   if (argc > 1) device = atoi(argv[1]);
-  if (argc > 2) width = atoi(argv[2]);
-  if (argc > 3) height = atoi(argv[3]);
+  if (argc > 2) out_w = atoi(argv[2]);
+  if (argc > 3) out_h = atoi(argv[3]);
   if (argc > 4) fps = atoi(argv[4]);
   if (argc > 5) roi_x = atoi(argv[5]);
   if (argc > 6) roi_y = atoi(argv[6]);
   if (argc > 7) roi_w = atoi(argv[7]);
   if (argc > 8) roi_h = atoi(argv[8]);
-  if (argc > 9) warmup = atoi(argv[9]);
+  if (argc > 9) sensor_w = atoi(argv[9]);
+  if (argc > 10) sensor_h = atoi(argv[10]);
+  if (argc > 11) warmup = atoi(argv[11]);
 
-  // Normalized clip rect (mirrors ToNormalizedClipRect in the ROS node).
+  // Sensor (source) frame the clip is normalized over. Default: source==output.
+  const int src_w = sensor_w > 0 ? sensor_w : out_w;
+  const int src_h = sensor_h > 0 ? sensor_h : out_h;
+
+  // Normalized clip rect over the sensor frame (mirrors ToNormalizedClipRect).
   float cl = 0.f, ct = 0.f, cr = 1.f, cb = 1.f;
-  const bool roi_on = roi_w > 0 && roi_h > 0 && width > 0 && height > 0;
+  const bool roi_on = roi_w > 0 && roi_h > 0 && src_w > 0 && src_h > 0;
   if (roi_on) {
-    cl = clamp01(static_cast<float>(roi_x) / width);
-    ct = clamp01(static_cast<float>(roi_y) / height);
-    cr = clamp01(static_cast<float>(roi_x + roi_w) / width);
-    cb = clamp01(static_cast<float>(roi_y + roi_h) / height);
+    cl = clamp01(static_cast<float>(roi_x) / src_w);
+    ct = clamp01(static_cast<float>(roi_y) / src_h);
+    cr = clamp01(static_cast<float>(roi_x + roi_w) / src_w);
+    cb = clamp01(static_cast<float>(roi_y + roi_h) / src_h);
   }
+  // scale = output / clipped-source-pixels. 1.0 => true 1:1 crop; >1 => zoom.
+  const float clip_px_w = (cr - cl) * src_w;
+  const float scale = clip_px_w > 0.f ? out_w / clip_px_w : 0.f;
   std::cout << "ROI " << (roi_on ? "ENABLED" : "disabled") << " x=" << roi_x
-            << " y=" << roi_y << " w=" << roi_w << " h=" << roi_h
-            << " -> clip [" << cl << ", " << ct << ", " << cr << ", " << cb
-            << "]  output " << width << "x" << height << std::endl;
+            << " y=" << roi_y << " w=" << roi_w << " h=" << roi_h << " over "
+            << "sensor " << src_w << "x" << src_h << " -> clip [" << cl << ", "
+            << ct << ", " << cr << ", " << cb << "]  output " << out_w << "x"
+            << out_h << "  scale=" << scale << "x ("
+            << (std::abs(scale - 1.f) < 0.01f ? "true 1:1 crop" : "zoom") << ")"
+            << std::endl;
 
   oc::ArgusCameraConfig config;
   config.mDeviceId = device;
-  config.mWidth = width;
-  config.mHeight = height;
+  config.mWidth = out_w;
+  config.mHeight = out_h;
+  config.mSensorWidth = sensor_w;   // 0 => sensor mode == output
+  config.mSensorHeight = sensor_h;
   config.mFPS = fps;
   config.verbose_level = 1;
   config.mClipLeft = cl;
@@ -68,7 +88,7 @@ int main(int argc, char* argv[]) {
   oc::ArgusBayerCapture camera;
   oc::ARGUS_STATE state = camera.openCamera(config);
   if (state != oc::ARGUS_STATE::OK) {
-    // An invalid clip rect trips the new validation -> INVALID_SOURCE_CONFIGURATION.
+    // Invalid clip or unavailable sensor mode -> INVALID_SOURCE_CONFIGURATION.
     std::cerr << "openCamera failed: " << oc::ARGUS_STATE2str(state) << std::endl;
     return 1;
   }
@@ -93,9 +113,9 @@ int main(int argc, char* argv[]) {
 
   cv::Mat bgr;
   cv::cvtColor(rgba, bgr, cv::COLOR_RGBA2BGR);
-  char name[128];
-  snprintf(name, sizeof(name), "roi_x%d_y%d_w%d_h%d.png", roi_x, roi_y, roi_w,
-           roi_h);
+  char name[160];
+  snprintf(name, sizeof(name), "roi_x%d_y%d_w%d_h%d_s%dx%d.png", roi_x, roi_y,
+           roi_w, roi_h, src_w, src_h);
   cv::imwrite(name, bgr);
   std::cout << "Wrote " << name << " (" << bgr.cols << "x" << bgr.rows << ")"
             << std::endl;


### PR DESCRIPTION
## Summary

Adds a configurable **ISP source-clip rect** (ROI crop / digital zoom) to `ArgusCameraConfig`, plus the ability to decouple sensor readout resolution from output resolution so a clip can yield a true native-detail crop instead of a digital zoom.

## What's here

- **Normalized clip rect** — `mClipLeft/Top/Right/Bottom` in `[0,1]` over the source frame (full frame = `{0,0,1,1}`). Clips the source and rescales to `mWidth x mHeight` via the ISP.
- **Sensor-mode decoupling** — `mSensorWidth/mSensorHeight` (0 = source == output). Setting the sensor readout larger than the output lets a centered clip produce a **1:1 native-detail crop** rather than upscaling (e.g. sensor 3840x2160, output 1920x1080, centered clip → native center crop).
- **`sample_roi/`** — standalone ISP clip-rect smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
